### PR TITLE
speed up CI a bit by making the matrix smaller

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,9 @@ jobs:
         python-version: 3.7
 
     - name: Install deps
-      run: python -mpip install -r requirements-dev.txt
+      run: |
+        python -mpip install wheel
+        python -mpip install -r requirements-dev.txt
 
     - name: Test
       run: make coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
         - '3.11.0-beta.1 - 3.11.0'
         - 'pypy-3.7'
         - 'pypy-3.8'
+        - 'pypy-3.9'
         os-version:
         - 'ubuntu-latest'
         include:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,11 @@ jobs:
         - 'pypy-3.8'
         os-version:
         - 'ubuntu-20.04'
-        - 'macos-latest'
-        - 'windows-latest'
+        include:
+          - os-version: 'macos-latest'
+            python-version: '3.10'
+          - os-version: 'windows-latest'
+            python-version: '3.10'
 
     runs-on: ${{ matrix.os-version }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install deps
-      run: python -mpip install -r requirements-dev.txt
+      run: |
+        python -mpip install wheel
+        python -mpip install -r requirements-dev.txt
 
     - name: Check stubs
       if: (! startsWith(matrix.python-version, 'pypy-'))

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         - 'pypy-3.7'
         - 'pypy-3.8'
         os-version:
-        - 'ubuntu-20.04'
+        - 'ubuntu-latest'
         include:
           - os-version: 'macos-latest'
             python-version: '3.10'


### PR DESCRIPTION
in particular, getting rid of pypy on non-linux platforms seems to really help.