### PR TITLE
Complete coverage. Drop python <3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,13 +17,9 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - '3.7'
-        - '3.8'
         - '3.9'
         - '3.10'
         - '3.11.0-rc.1 - 3.11'
-        - 'pypy-3.7'
-        - 'pypy-3.8'
         - 'pypy-3.9'
         os-version:
         - 'ubuntu-latest'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,6 +16,5 @@ twine; implementation_name=="cpython"
 types-beautifulsoup4
 types-python-dateutil
 types-requests
-backports.zoneinfo; python_version<"3.9"
 tzdata
 wheel

--- a/src/wwvb/__init__.py
+++ b/src/wwvb/__init__.py
@@ -17,6 +17,7 @@ from . import iersdata
 from .tz import Mountain
 
 HOUR = datetime.timedelta(seconds=3600)
+SECOND = datetime.timedelta(seconds=1)
 DateOrDatetime = TypeVar("DateOrDatetime", datetime.date, datetime.datetime)
 T = TypeVar("T")  # pylint: disable=invalid-name
 
@@ -118,7 +119,9 @@ def get_dst_change_hour(
     for i in (1, 2, 3, 4):
         lt1 = (lt0.astimezone(datetime.timezone.utc) + HOUR * i).astimezone(tz)
         dst1 = lt1.dst()
-        if dst0 != dst1:
+        lt2 = lt1 - SECOND
+        dst2 = lt2.dst()
+        if dst0 == dst2 and dst0 != dst1:
             return i - 1
     return None
 

--- a/src/wwvb/__init__.py
+++ b/src/wwvb/__init__.py
@@ -259,11 +259,12 @@ def get_dst_next(d: DateOrDatetime, tz: datetime.tzinfo = Mountain) -> int:
         return 0b100011
 
     dst_change_date, dst_next_row = get_dst_change_date_and_row(d, tz)
-    if dst_change_date is None or dst_next_row is None:  # pragma no coverage
+    if dst_change_date is None:
         return 0b100011
+    assert dst_next_row is not None
 
     dst_change_hour = get_dst_change_hour(dst_change_date, tz)
-    if dst_change_hour is None:  # pragma no coverage
+    if dst_change_hour is None:
         return 0b100011
 
     return dsttable[dst_now][dst_change_hour][dst_next_row]

--- a/src/wwvb/testwwvb.py
+++ b/src/wwvb/testwwvb.py
@@ -364,6 +364,23 @@ class WWVBRoundtrip(unittest.TestCase):
         self.assertIsNone(date)
         self.assertIsNone(row)
 
+        # California was weird in 1948
+        self.assertEqual(
+            wwvb.get_dst_next(
+                datetime.datetime(1948, 1, 1), tz=tz.ZoneInfo("America/Los_Angeles")
+            ),
+            0b100011,
+        )
+
+        # Berlin had DST changes on Monday in 1917
+        self.assertEqual(
+            wwvb.get_dst_next(
+                datetime.datetime(1917, 1, 1), tz=tz.ZoneInfo("Europe/Berlin")
+            ),
+            0b100011,
+        )
+
+        #
         # Australia observes DST in the other half of the year compared to the
         # Northern hemisphere
         self.assertEqual(

--- a/src/wwvb/tz.py
+++ b/src/wwvb/tz.py
@@ -6,16 +6,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-only
 
-import datetime
-import sys
-from typing import Callable
-
-ZoneInfo: Callable[[str], datetime.tzinfo]
-
-if sys.version_info >= (3, 9):  # pragma no coverage
-    from zoneinfo import ZoneInfo
-else:  # pragma no coverage
-    from backports.zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo
 
 Mountain = ZoneInfo("America/Denver")
 


### PR DESCRIPTION
And fix a VERY obscure error about DST changes not exactly on an hour boundary