### PR TITLE
Prevent ruff from formatting iersdata & remove pylint directives altogether

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -1,4 +1,3 @@
-# pylint: disable=all
 # fmt: off
 # Configuration file for the Sphinx documentation builder.
 #

--- a/src/uwwvb.py
+++ b/src/uwwvb.py
@@ -87,7 +87,7 @@ def get_am_bcd(seq: list[int], *poslist: int) -> int | None:
     return result
 
 
-def decode_wwvb(  # pylint: disable=too-many-return-statements
+def decode_wwvb(
     t: list[int] | None,
 ) -> WWVBMinute | None:
     """Convert a received minute of wwvb symbols to a WWVBMinute.  Returns None if any error is detected."""

--- a/src/wwvb/__init__.py
+++ b/src/wwvb/__init__.py
@@ -19,7 +19,7 @@ from .tz import Mountain
 HOUR = datetime.timedelta(seconds=3600)
 SECOND = datetime.timedelta(seconds=1)
 DateOrDatetime = TypeVar("DateOrDatetime", datetime.date, datetime.datetime)
-T = TypeVar("T")  # pylint: disable=invalid-name
+T = TypeVar("T")
 
 
 def require(x: Optional[T]) -> T:
@@ -336,7 +336,7 @@ class WWVBMinute(_WWVBMinute):
 
     epoch: int = 1970
 
-    def __new__(  # pylint: disable=too-many-arguments
+    def __new__(
         cls,
         year: int,
         days: int,
@@ -534,9 +534,7 @@ class WWVBMinute(_WWVBMinute):
         for i in range(60):
             t._put_pm_bit(i, full_seq[i + offset])
 
-    def fill_pm_timecode_regular(  # pylint: disable=too-many-statements
-        self, t: "WWVBTimecode"
-    ) -> None:
+    def fill_pm_timecode_regular(self, t: "WWVBTimecode") -> None:
         """Except during minutes 10..15 and 40..45, the amplitude signal holds 'regular information'"""
         t._put_pm_bin(0, 13, SYNC_T)
 
@@ -610,9 +608,7 @@ class WWVBMinute(_WWVBMinute):
         return self.from_datetime(d, newut1, newls, self)
 
     @classmethod
-    def _get_dut1_info(  # pylint: disable=unused-argument
-        cls: type, year: int, days: int, old_time: "Optional[WWVBMinute]" = None
-    ) -> Tuple[int, bool]:
+    def _get_dut1_info(cls: type, year: int, days: int, old_time: "Optional[WWVBMinute]" = None) -> Tuple[int, bool]:
         """Return the DUT1 information for a given day, possibly propagating information from a previous timestamp"""
         if old_time is not None:
             if old_time.minute_length() != 60:
@@ -664,9 +660,7 @@ class WWVBMinute(_WWVBMinute):
         return cls(u.tm_year, u.tm_yday, u.tm_hour, u.tm_min, ut1=newut1, ls=newls)
 
     @classmethod
-    def from_timecode_am(  # pylint: disable=too-many-return-statements
-        cls, t: "WWVBTimecode"
-    ) -> Optional["WWVBMinute"]:
+    def from_timecode_am(cls, t: "WWVBTimecode") -> Optional["WWVBMinute"]:
         """Construct a WWVBMinute from a WWVBTimecode"""
         for i in (0, 9, 19, 29, 39, 49, 59):
             if t.am[i] != AmplitudeModulation.MARK:
@@ -748,7 +742,7 @@ class WWVBTimecode:
     phase: List[PhaseModulation]
 
     def __init__(self, sz: int) -> None:
-        self.am = [AmplitudeModulation.UNSET] * sz  # pylint: disable=invalid-name
+        self.am = [AmplitudeModulation.UNSET] * sz
         self.phase = [PhaseModulation.UNSET] * sz
 
     def _get_am_bcd(self, *poslist: int) -> Optional[int]:
@@ -835,7 +829,6 @@ styles = {
 }
 
 
-# pylint: disable=too-many-arguments
 def print_timecodes(
     w: WWVBMinute,
     minutes: int,
@@ -873,7 +866,6 @@ def print_timecodes(
         w = w.next_minute()
 
 
-# pylint: disable=too-many-arguments
 def print_timecodes_json(
     w: WWVBMinute,
     minutes: int,

--- a/src/wwvb/decode.py
+++ b/src/wwvb/decode.py
@@ -23,7 +23,7 @@ import wwvb
 always_zero = set((4, 10, 11, 14, 20, 21, 34, 35, 44, 54))
 
 
-def wwvbreceive() -> Generator[Optional[wwvb.WWVBTimecode], wwvb.AmplitudeModulation, None]:  # pylint: disable=too-many-branches
+def wwvbreceive() -> Generator[Optional[wwvb.WWVBTimecode], wwvb.AmplitudeModulation, None]:
     """A stateful decoder of WWVB signals"""
     minute: List[wwvb.AmplitudeModulation] = []
     state = 1

--- a/src/wwvb/gen.py
+++ b/src/wwvb/gen.py
@@ -16,9 +16,7 @@ import dateutil.parser
 from . import WWVBMinute, WWVBMinuteIERS, print_timecodes, print_timecodes_json, styles
 
 
-def parse_timespec(  # pylint: disable=unused-argument
-    ctx: Any, param: Any, value: List[str]
-) -> datetime.datetime:
+def parse_timespec(ctx: Any, param: Any, value: List[str]) -> datetime.datetime:
     """Parse a time specifier from the commandline"""
     try:
         if len(value) == 5:
@@ -87,7 +85,6 @@ def parse_timespec(  # pylint: disable=unused-argument
     help="Modulation to show (default: amplitude)",
 )
 @click.argument("timespec", type=str, nargs=-1, callback=parse_timespec)
-# pylint: disable=too-many-arguments, too-many-locals
 def main(
     iers: bool,
     leap_second: bool,

--- a/src/wwvb/iersdata.py
+++ b/src/wwvb/iersdata.py
@@ -21,7 +21,7 @@ for location in [
     filename = os.path.join(location, "wwvbpy_iersdata.py")
     if os.path.exists(filename):
         with open(filename, encoding="utf-8") as f:
-            exec(f.read(), globals(), globals())  # pylint: disable=exec-used
+            exec(f.read(), globals(), globals())
         break
 
 start = datetime.datetime.combine(DUT1_DATA_START, datetime.time()).replace(tzinfo=datetime.timezone.utc)

--- a/src/wwvb/iersdata_dist.py
+++ b/src/wwvb/iersdata_dist.py
@@ -1,8 +1,8 @@
 # -*- python3 -*-
+# fmt: off
 """File generated from public data - not subject to copyright"""
 # SPDX-FileCopyrightText: Public domain
 # SPDX-License-Identifier: CC0-1.0
-# fmt: off
 # isort: skip_file
 # pylint: disable=invalid-name
 import datetime

--- a/src/wwvb/iersdata_dist.py
+++ b/src/wwvb/iersdata_dist.py
@@ -4,7 +4,6 @@
 # SPDX-FileCopyrightText: Public domain
 # SPDX-License-Identifier: CC0-1.0
 # isort: skip_file
-# pylint: disable=invalid-name
 import datetime
 __all__ = ['DUT1_DATA_START', 'DUT1_OFFSETS']
 DUT1_DATA_START = datetime.date(1972, 1, 1)

--- a/src/wwvb/testcli.py
+++ b/src/wwvb/testcli.py
@@ -6,8 +6,6 @@
 #
 # SPDX-License-Identifier: GPL-3.0-only
 
-# pylint: disable=invalid-name
-
 import json
 import os
 import subprocess

--- a/src/wwvb/testuwwvb.py
+++ b/src/wwvb/testuwwvb.py
@@ -21,9 +21,7 @@ EitherDatetimeOrNone = Union[None, datetime.datetime, adafruit_datetime.datetime
 class WWVBRoundtrip(unittest.TestCase):
     """tests of uwwvb.py"""
 
-    def assertDateTimeEqualExceptTzInfo(  # pylint: disable=invalid-name
-        self, a: EitherDatetimeOrNone, b: EitherDatetimeOrNone
-    ) -> None:
+    def assertDateTimeEqualExceptTzInfo(self, a: EitherDatetimeOrNone, b: EitherDatetimeOrNone) -> None:
         """Test two datetime objects for equality
 
         This equality test excludes tzinfo, and allows adafruit_datetime and core datetime modules to compare equal"""

--- a/src/wwvb/testwwvb.py
+++ b/src/wwvb/testwwvb.py
@@ -27,7 +27,6 @@ class WWVBMinute2k(wwvb.WWVBMinute):
     epoch = 2000
 
 
-# pylint: disable=too-many-locals
 class WWVBTestCase(unittest.TestCase):
     """Test each expected output in tests/.  Some outputs are from another program, some are from us"""
 

--- a/src/wwvb/updateiers.py
+++ b/src/wwvb/updateiers.py
@@ -45,7 +45,7 @@ def _get_text(url: str) -> str:
         return open(url, encoding="utf-8").read()
 
 
-def update_iersdata(  # pylint: disable=too-many-locals, too-many-branches, too-many-statements
+def update_iersdata(
     target_file: str,
 ) -> None:
     """Update iersdata.py"""
@@ -135,7 +135,6 @@ def update_iersdata(  # pylint: disable=too-many-locals, too-many-branches, too-
         code("# SPDX" + "-FileCopyrightText: Public domain")
         code("# SPDX" + "-License-Identifier: CC0-1.0")
         code("# isort: skip_file")
-        code("# pylint: disable=invalid-name")
         code("import datetime")
 
         code("__all__ = ['DUT1_DATA_START', 'DUT1_OFFSETS']")

--- a/src/wwvb/updateiers.py
+++ b/src/wwvb/updateiers.py
@@ -130,10 +130,10 @@ def update_iersdata(  # pylint: disable=too-many-locals, too-many-branches, too-
             print(*args, file=output)
 
         code("# -*- python3 -*-")
+        code("# fmt: off")
         code('"""File generated from public data - not subject to copyright"""')
         code("# SPDX" + "-FileCopyrightText: Public domain")
         code("# SPDX" + "-License-Identifier: CC0-1.0")
-        code("# fmt: off")
         code("# isort: skip_file")
         code("# pylint: disable=invalid-name")
         code("import datetime")

--- a/src/wwvb/wwvbtk.py
+++ b/src/wwvb/wwvbtk.py
@@ -9,7 +9,7 @@
 import functools
 import threading
 import time
-from tkinter import Canvas, TclError, Tk  # pylint: disable=import-error
+from tkinter import Canvas, TclError, Tk
 from typing import Any, Generator, Optional, Tuple
 
 import click
@@ -23,9 +23,7 @@ def _app() -> Tk:
     return Tk()
 
 
-def validate_colors(  # pylint: disable=unused-argument
-    ctx: Any, param: Any, value: str
-) -> list[str]:
+def validate_colors(ctx: Any, param: Any, value: str) -> list[str]:
     """Check that all colors in a string are valid, splitting it to a list"""
     app = _app()
     colors = value.split()


### PR DESCRIPTION
A ruff update added a blank line before the docstring. Prevent it
by moving the fmt:off directive even earlier.