### PR TITLE
add requirements for distribution building

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,8 +67,11 @@ jobs:
       if: (! startsWith(matrix.python-version, 'pypy-'))
       run: make mypy PYTHON=python
 
-    - name: Test
+    - name: Coverage
       run: make coverage PYTHON=python
+
+    - name: Test installed version
+      run: make test_venv PYTHON=python
 
     - name: Upload Coverage as artifact
       if: always()

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,11 @@ STEPECHO = @echo
 endif
 
 PYTHON ?= python3
+ifeq ($(OS),Windows_NT)
+ENVPYTHON ?= _env/Scripts/python.exe
+else
+ENVPYTHON ?= _env/bin/python3
+endif
 
 .PHONY: default
 default: coverage mypy
@@ -30,6 +35,12 @@ coverage:
 	$(Q)$(PYTHON) -mcoverage html $(COVERAGE_INCLUDE)
 	$(Q)$(PYTHON) -mcoverage xml $(COVERAGE_INCLUDE)
 	$(Q)$(PYTHON) -mcoverage report --fail-under=100 $(COVERAGE_INCLUDE)
+
+.PHONY: test_venv
+test_venv:
+	$(Q)$(PYTHON) -mvenv --clear _env
+	$(Q)$(ENVPYTHON) -mpip install .
+	$(Q)$(ENVPYTHON) -m unittest discover -s test
 
 .PHONY: mypy
 mypy:
@@ -53,7 +64,7 @@ BUILDDIR      = _build
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 .PHONY: html
 html:
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	$(Q)$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 # SPDX-FileCopyrightText: 2024 Jeff Epler
 #

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2021-2024 Jeff Epler
+#
+# SPDX-License-Identifier: GPL-3.0-only
+adafruit-circuitpython-datetime
+beautifulsoup4
+click
+leapseconddata
+platformdirs
+python-dateutil
+requests
+tzdata


### PR DESCRIPTION
The requirements.txt was not added when setup.cfg was dropped, so no dependencies were being installed with pip! add requirements.txt and use a new venv test to make sure it actually works.