### PR TITLE
welcome to doc dependency hell

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,8 +16,10 @@ import os
 import re
 import subprocess
 import sys
+import pathlib
 
-sys.path.insert(0, os.path.abspath("."))
+ROOT = pathlib.Path(__file__).absolute().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
 
 
 # -- Project information -----------------------------------------------------

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,9 +14,9 @@ pre-commit
 python-dateutil
 requests; implementation_name=="cpython"
 setuptools>=68; implementation_name=="cpython"
-sphinx
-sphinx-autodoc-typehints
-sphinx-rtd-theme
+sphinx>=8.0.2,<9
+sphinx-autodoc-typehints>=2.4.1,<3
+sphinx-rtd-theme>=3.0.0rc1,<4
 twine; implementation_name=="cpython"
 types-beautifulsoup4; implementation_name=="cpython"
 types-python-dateutil; implementation_name=="cpython"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,9 +14,9 @@ pre-commit
 python-dateutil
 requests; implementation_name=="cpython"
 setuptools>=68; implementation_name=="cpython"
-sphinx>=8.0.2,<9
-sphinx-autodoc-typehints>=2.4.1,<3
-sphinx-rtd-theme>=3.0.0rc1,<4
+sphinx>=7,<8
+sphinx-autodoc-typehints
+sphinx-rtd-theme
 twine; implementation_name=="cpython"
 types-beautifulsoup4; implementation_name=="cpython"
 types-python-dateutil; implementation_name=="cpython"


### PR DESCRIPTION
sphinx-rtd-theme 2.0.0 declares that it is incompatible with sphinx 8. As a result, with the old requirements-dev.txt, sphinx 8 and sphinx-rtd-theme 0.mumble are installed, as sphinx-rtd-theme 0.mumble did NOT declare an explicit incompatibility with sphinx 8.

This pairing emphatically does NOT work, giving the error `UndefinedError("'style' is undefined")` during doc building.

For all these AWESOME packages, specify a dependency range. This is sure to prevent future breakage 😉

Only we use sphinx 7 because sphinx 8 drops 3.9 support and we want 3.9 support for now (it's about 13 months from EOL and is the version in oldstable)