### PR TITLE
Update ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
   - id: reuse
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.11.7
+  rev: v0.12.1
   hooks:
     # Run the linter.
     - id: ruff

--- a/src/uwwvb.py
+++ b/src/uwwvb.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-only
 
-# ruff: noqa: C405 PYI024 PLR2004 FBT001 FBT002
+# ruff: noqa: C405, PYI024, FBT001, FBT002
 
 """Implementation of a WWVB state machine & decoder for resource-constrained systems
 

--- a/src/wwvb/__init__.py
+++ b/src/wwvb/__init__.py
@@ -384,6 +384,7 @@ class WWVBMinute(_WWVBMinute):
         minute: int,
         dst: DstStatus | int | None = None,
         ut1: int | None = None,
+        *,
         ls: bool | None = None,
         ly: bool | None = None,
     ) -> WWVBMinute:
@@ -659,15 +660,15 @@ class WWVBMinute(_WWVBMinute):
         else:
             self._fill_pm_timecode_regular(t)
 
-    def next_minute(self, newut1: int | None = None, newls: bool | None = None) -> WWVBMinute:
+    def next_minute(self, *, newut1: int | None = None, newls: bool | None = None) -> WWVBMinute:
         """Return an object representing the next minute"""
         d = self.as_datetime() + datetime.timedelta(minutes=1)
-        return self.from_datetime(d, newut1, newls, self)
+        return self.from_datetime(d, newut1=newut1, newls=newls, old_time=self)
 
-    def previous_minute(self, newut1: int | None = None, newls: bool | None = None) -> WWVBMinute:
+    def previous_minute(self, *, newut1: int | None = None, newls: bool | None = None) -> WWVBMinute:
         """Return an object representing the previous minute"""
         d = self.as_datetime() - datetime.timedelta(minutes=1)
-        return self.from_datetime(d, newut1, newls, self)
+        return self.from_datetime(d, newut1=newut1, newls=newls, old_time=self)
 
     @classmethod
     def _get_dut1_info(cls: type, year: int, days: int, old_time: WWVBMinute | None = None) -> tuple[int, bool]:  # noqa: ARG003
@@ -696,18 +697,19 @@ class WWVBMinute(_WWVBMinute):
         days = d.pop("days")
         hour = d.pop("hour")
         minute = d.pop("minute")
-        dst: int | None = d.pop("dst", None)
-        ut1: int | None = d.pop("ut1", None)
+        dst = d.pop("dst", None)
+        ut1 = d.pop("ut1", None)
         ls = d.pop("ls", None)
         d.pop("ly", None)
         if d:
             raise ValueError(f"Invalid options: {d}")
-        return cls(year, days, hour, minute, dst, ut1, None if ls is None else bool(ls))
+        return cls(year, days, hour, minute, dst, ut1=ut1, ls=None if ls is None else bool(ls))
 
     @classmethod
     def from_datetime(
         cls,
         d: datetime.datetime,
+        *,
         newut1: int | None = None,
         newls: bool | None = None,
         old_time: WWVBMinute | None = None,
@@ -760,7 +762,7 @@ class WWVBMinute(_WWVBMinute):
         dst = t._get_am_bcd(57, 58)
         if dst is None:
             return None
-        return cls(year, days, hour, minute, dst, ut1, ls, ly)
+        return cls(year, days, hour, minute, dst, ut1, ls=ls, ly=ly)
 
 
 class WWVBMinuteIERS(WWVBMinute):
@@ -858,7 +860,7 @@ class WWVBTimecode:
             else:
                 self.am[p] = AmplitudeModulation.ZERO
 
-    def _put_pm_bit(self, i: int, v: PhaseModulation | int | bool) -> None:
+    def _put_pm_bit(self, i: int, v: PhaseModulation | int) -> None:
         """Update a bit of the Phase Modulation signal"""
         self.phase[i] = PhaseModulation(v)
 

--- a/test/testuwwvb.py
+++ b/test/testuwwvb.py
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-only
 
-# ruff: noqa: N802 D102
+# ruff: noqa: N802
 import datetime
 import random
 import sys

--- a/test/testwwvb.py
+++ b/test/testwwvb.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# ruff: noqa: E501
 
 """Test most wwvblib functionality"""
 


### PR DESCRIPTION
New ruff is very opinionated about positional arguments that can take a boolean type. As a result, the signatures of the following functions have changed:
 * WWVBMinute: ls, ly are keyword-only
 * next_minute, previous_minute: newut1 and newls are keyword-only
 * from_datetime: newut1, newls, and old_time are keyword-only