### PR TITLE
WWVBMinute: correct typing of __new__ method

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,5 +22,6 @@ twine; implementation_name=="cpython"
 types-beautifulsoup4; implementation_name=="cpython"
 types-python-dateutil; implementation_name=="cpython"
 types-requests; implementation_name=="cpython"
+typing-extensions; implementation_name=="cpython"
 tzdata
 wheel

--- a/src/wwvb/__init__.py
+++ b/src/wwvb/__init__.py
@@ -21,6 +21,8 @@ import json
 import warnings
 from typing import TYPE_CHECKING, Any, NamedTuple, TextIO, TypeVar
 
+from typing_extensions import Self
+
 from . import iersdata
 from .tz import Mountain
 
@@ -376,7 +378,7 @@ class WWVBMinute(_WWVBMinute):
 
     epoch: int = 1970
 
-    def __new__(  # noqa: PYI034
+    def __new__(
         cls,
         year: int,
         days: int,
@@ -387,7 +389,7 @@ class WWVBMinute(_WWVBMinute):
         *,
         ls: bool | None = None,
         ly: bool | None = None,
-    ) -> WWVBMinute:
+    ) -> Self:
         """Construct a WWVBMinute
 
         :param year: The 2- or 4-digit year. This parameter is converted by the `full_year` method.


### PR DESCRIPTION
In making a reproducer for https://github.com/facebook/pyrefly/issues/761 I found that there was a better way to specify the type of the the `__new__` method.